### PR TITLE
fix(typescript): fix query typings

### DIFF
--- a/typings/get-queries-for-element.d.ts
+++ b/typings/get-queries-for-element.d.ts
@@ -1,6 +1,7 @@
 import { ReactTestRenderer } from 'react-test-renderer';
 
 import * as queries from './queries';
+import { NativeTestInstance } from './query-helpers';
 
 export type BoundFunction<T> = T extends (
   attribute: string,
@@ -17,10 +18,10 @@ export type BoundFunctions<T> = { [P in keyof T]: BoundFunction<T[P]> };
 interface Query extends Function {
   (testRenderer: ReactTestRenderer, ...args: any[]):
     | Error
-    | Promise<ReactTestRenderer[]>
-    | Promise<ReactTestRenderer>
-    | ReactTestRenderer[]
-    | ReactTestRenderer
+    | Promise<NativeTestInstance[]>
+    | Promise<NativeTestInstance>
+    | NativeTestInstance[]
+    | NativeTestInstance
     | null;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,10 +12,10 @@ declare const within: typeof getQueriesForElement;
 interface Query extends Function {
   (testRenderer: ReactTestRenderer | NativeTestInstance, ...args: any[]):
     | Error
-    | Promise<HTMLElement[]>
-    | Promise<HTMLElement>
-    | HTMLElement[]
-    | HTMLElement
+    | Promise<NativeTestInstance[]>
+    | Promise<NativeTestInstance>
+    | NativeTestInstance[]
+    | NativeTestInstance
     | null;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -10,7 +10,7 @@ import { getQueriesForElement, BoundFunction } from './get-queries-for-element';
 declare const within: typeof getQueriesForElement;
 
 interface Query extends Function {
-  (testRenderer: ReactTestRenderer | NativeTestInstance, ...args: any[]):
+  (testRenderer: ReactTestRenderer, ...args: any[]):
     | Error
     | Promise<NativeTestInstance[]>
     | Promise<NativeTestInstance>

--- a/typings/query-helpers.d.ts
+++ b/typings/query-helpers.d.ts
@@ -4,9 +4,9 @@ import { Matcher, MatcherOptions } from './matches';
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export interface SelectorMatcherOptions extends MatcherOptions {
+export type SelectorMatcherOptions = Omit<MatcherOptions, 'selector'> & {
   selector?: string;
-}
+};
 
 type ReactTestInstance = {
   getProp: (string) => NativeTestInstance;

--- a/typings/query-helpers.d.ts
+++ b/typings/query-helpers.d.ts
@@ -8,7 +8,7 @@ export type SelectorMatcherOptions = Omit<MatcherOptions, 'selector'> & {
   selector?: string;
 };
 
-type ReactTestInstance = ReactTestInstance & {
+type ReactTestInstance = {
   getProp: (str: string) => NativeTestInstance;
 };
 

--- a/typings/query-helpers.d.ts
+++ b/typings/query-helpers.d.ts
@@ -8,8 +8,8 @@ export type SelectorMatcherOptions = Omit<MatcherOptions, 'selector'> & {
   selector?: string;
 };
 
-type ReactTestInstance = {
-  getProp: (string) => NativeTestInstance;
+type ReactTestInstance = ReactTestInstance & {
+  getProp: (str: string) => NativeTestInstance;
 };
 
 export type NativeTestInstance = Omit<


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:
Fix Query typings.
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
Typings error occurred because of incompatible with Query interface.
<!-- Why are these changes necessary? -->

**How**:
- [x] Use `NativeTestInstance` type for returning Query interface.
- [x] Remove `NativeTestInstance` type from `testRenderer` argument in Query interface.
- [x] Fix `ReactTestInstance.getProps` type.

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->


Results:
```
$ yarn tsc                                                                                                                                                                          
yarn run v1.15.2
$ /Users/me/workspace/react-native/react-native-sample/node_modules/.bin/tsc
✨  Done in 30.35s.
```
